### PR TITLE
Fix Maven problems preventing build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,10 +50,13 @@ processResources {
 repositories {
 	maven {
 		name "shadowfacts"
-		url "http://mvn.rx14.co.uk/shadowfacts/"
+		url "http://maven.shadowfacts.net/"
 	}
 	maven {
 		url "http://dvs1.progwml6.com/files/maven"
+	}
+	maven {
+		url "https://dl.bintray.com/kotlin/kotlinx/"
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,15 +48,13 @@ processResources {
 }
 
 repositories {
+	jcenter()
 	maven {
 		name "shadowfacts"
 		url "http://maven.shadowfacts.net/"
 	}
 	maven {
 		url "http://dvs1.progwml6.com/files/maven"
-	}
-	maven {
-		url "https://dl.bintray.com/kotlin/kotlinx/"
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,5 @@ mc_version = 1.12
 mcp_mappings = snapshot_20170625
 forge_version = 14.21.0.2363
 
-shadowmc_version = 3.8.0-SNAPSHOT
+shadowmc_version = 3.8.1-SNAPSHOT
 jei_version = 4.7.0.67


### PR DESCRIPTION
- Fix Maven URL per shadowfacts/ShadowMC#22
- Switch to 3.8.1-SNAPSHOT since 3.8.0-SNAPSHOT no longer exists
- Add kotlinx's Maven URL